### PR TITLE
Add polls released between 2014-09-14 and 2014-10-19

### DIFF
--- a/Data/Polls.csv
+++ b/Data/Polls.csv
@@ -1,4 +1,5 @@
 PublYearMonth,Company,M,FP,C,KD,S,V,MP,SD,FI,Uncertain,n,PublDate,collectPeriodFrom,collectPeriodTo,approxPeriod,house
+2014-okt,Sifo,24.7,4.9,6.1,4.5,26.6,7.1,10.0,12.4,3.0,NA,1921,2014-10-19,2014-10-06,2014-10-16,FALSE,Sifo
 2014-okt,Sentio,25.1,5.1,5.1,2.8,27.3,5.2,6.9,16.7,2.9,NA,1042,2014-10-14,2014-10-02,2014-10-08,FALSE,Sentio
 2014-okt,Demoskop,24.1,5.5,5.8,3.9,30.3,6.0,8.1,13.3,2.1,NA,1250,2014-10-13,2014-09-30,2014-10-08,FALSE,Demoskop
 2014-sep,Ipsos,24.0,5.6,6.1,4.2,30.7,6.2,7.1,12.4,2.9,11.9,1514,2014-09-26,2014-09-17,2014-09-24,FALSE,Ipsos


### PR DESCRIPTION
Included companies: Sifo, Sentio, Demoskop, Ipsos.
Remaining companies have not released any polls since the election.
