### PR TITLE
Update DCAT-AP automatically

### DIFF
--- a/.github/workflows/update-dcat-ap.yaml
+++ b/.github/workflows/update-dcat-ap.yaml
@@ -1,0 +1,28 @@
+name: Update DCAT-AP
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'Data/Polls.csv'
+
+jobs:
+  update-modified-date:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Update modified date in dcat-ap.rdf
+        run: |
+          TODAY=$(date +%Y-%m-%d)
+          sed -i -E 's|(<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">)[0-9]{4}-[0-9]{2}-[0-9]{2}(</dcterms:modified>)|\1'"$TODAY"'\2|' dcat-ap.rdf
+
+      - name: Commit and push
+        run: |
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config --global user.name 'github-actions[bot]'
+          git add dcat-ap.rdf
+          git commit -m 'Update the data' || echo "Nothing to commit"
+          git push


### PR DESCRIPTION
Two years after #246, here is a small PR adding a Github action to automate the update of the `modified` date in the DCAT-AP file every time _Data/Polls.csv_ is updated.

I haven't been able to test it properly as I can't trigger Github Actions myself.