### PR TITLE
New attempt, push to PR instead of master

### DIFF
--- a/.github/workflows/update-dcat-ap.yaml
+++ b/.github/workflows/update-dcat-ap.yaml
@@ -1,28 +1,58 @@
 name: Update DCAT-AP
 
 on:
-  push:
+  pull_request:
     branches:
       - master
     paths:
       - 'Data/Polls.csv'
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   update-modified-date:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout PR head
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update modified date in dcat-ap.rdf
         run: |
           TODAY=$(date +%Y-%m-%d)
           sed -i -E 's|(<dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">)[0-9]{4}-[0-9]{2}-[0-9]{2}(</dcterms:modified>)|\1'"$TODAY"'\2|' dcat-ap.rdf
 
-      - name: Commit and push
+      - name: Commit changes (if any)
         run: |
-          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git config --global user.name 'github-actions[bot]'
+          TODAY=${TODAY:-$(date +%Y-%m-%d)}
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config user.name 'github-actions[bot]'
           git add dcat-ap.rdf
-          git commit -m 'Update the data' || echo "Nothing to commit"
-          git push
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -m "chore: update dcat-ap.rdf modified date to ${TODAY}"
+
+      - name: Push back to PR branch
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        run: |
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
+      - name: Notify on forks (cannot push)
+        if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: "This workflow updated dcat-ap.rdf locally but cannot push changes to a forked PR. Please update the <dcterms:modified> date to today in dcat-ap.rdf."
+            })


### PR DESCRIPTION
Here's a new approach to #354. It pushes the change to the PR instead of the `master` branch.