### PR TITLE
Add Demoskop for August 2025

### DIFF
--- a/Data/Polls.csv
+++ b/Data/Polls.csv
@@ -1,4 +1,5 @@
 PublYearMonth,Company,M,L,C,KD,S,V,MP,SD,FI,Uncertain,n,PublDate,collectPeriodFrom,collectPeriodTo,approxPeriod,house
+2025-aug,Demoskop,17.9,2.7,4.6,4.3,33.5,6.3,7.3,20.7,NA,NA,2071,2025-08-28,2025-08-14,2025-08-25,FALSE,Demoskop
 2025-aug,Novus,17.6,3.0,5.0,3.9,34.1,8.6,4.9,21.0,NA,NA,2212,2025-08-27,2025-08-11,2025-08-24,FALSE,Novus
 2025-aug,Sifo,18.3,2.8,5.4,3.5,33.9,7.0,6.3,20.5,NA,NA,3236,2025-08-20,2025-08-04,2025-08-17,FALSE,Sifo
 2025-jul,Sentio,17.2,3.3,3.3,4.5,33.0,8.6,5.1,22.6,NA,NA,764,2025-08-11,2025-07-10,2025-07-15,FALSE,Sentio


### PR DESCRIPTION
Source: 

https://www.aftonbladet.se/nyheter/a/1MErpQ/aftonbladet-demoskop-sd-kan-rucka-kristerssons-maktbalans

<img width="572" height="258" alt="image" src="https://github.com/user-attachments/assets/7b5f2d21-b598-433b-b441-671bb62ed4f9" />

> Undersökningen är gjord av Demoskop på uppdrag av Aftonbladet och Svenska Dagbladet inom ramen för Iniziopanelen som speglar svenska folket. Målgruppen är allmänheten 18 –79 år. Undersökningen omfattar 2 071 intervjuer under perioden 14 till 25 augusti 2025, och är genomförd som en webbundersökning.