### PR TITLE
Ipsos update june

### DIFF
--- a/Data/Polls.csv
+++ b/Data/Polls.csv
@@ -1,4 +1,5 @@
 PublYearMonth,Company,M,L,C,KD,S,V,MP,SD,FI,Uncertain,n,PublDate,collectPeriodFrom,collectPeriodTo,approxPeriod,house
+2026-jun,Ipsos,17,1,6,6,31,10,7,19,NA,NA,1619,2026-06-16,2026-06-02,2026-06-14,FALSE,Ipsos
 2026-jun,Sifo,17.1,2.0,5.4,6.0,31.6,8.7,7.8,18.9,NA,15,3011,2026-06-13,2026-05-25,2026-06-07,FALSE,Sifo
 2026-juni,SCB,17.3,2.5,6.1,4.5,33.9,8.6,6.6,18.3,NA,NA,4542,2026-06-04,2026-04-28,2026-05-28,FALSE,SCB
 2026-maj,Demoskop,16.7,3.1,6.0,5.7,31.9,7.6,8.1,19.0,NA,NA,2081,2026-05-28,2026-05-17,2026-05-24,FALSE,Demoskop


### PR DESCRIPTION
Updated with ipsos poll

https://www.dn.se/sverige/nytt-bottenrekord-for-liberalerna-tido-halkar-efter/